### PR TITLE
Fix: [Web App] Make EsLint scream for indent and trailing white spaces.

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -19,6 +19,8 @@
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/consistent-type-definitions": ["error"],
     "quotes": ["error", "single"],
-    "semi": ["error", "always"]
+    "semi": ["error", "always"],
+    "indent": ["error", 2],
+    "no-trailing-spaces": ["error", { "skipBlankLines": true }]
   }
 }


### PR DESCRIPTION
**This pull request makes the following changes**
* Fix https://github.com/code-collabo/collabo-community-app/issues/69 

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

- [x] Eslint screams when indent is not 2
- [x] Eslint screams when trailing white space is left at the end (right side) of a line of code.
- [x] I've checked that Eslint screams the above both (in form of wiggly lines) in code editor's interface, and in the terminal when you run any of the lint commands
- [x] I've checked that Eslint screams both in js and ts files
- [x] I certify that I ran my checklist

Ping @code-collabo/web-app

